### PR TITLE
Actions workflow: condition of nothing changes

### DIFF
--- a/.github/workflows/L1_topo.yaml
+++ b/.github/workflows/L1_topo.yaml
@@ -48,7 +48,12 @@ jobs:
     - name: convert format inet-henge to batfish
       run: python3 inet-henge2batfish.py ../inet-henge/netbox.json > ../mddo_network/layer1_topology.json
 
+    - name: Count file changes
+      id: changes
+      run: echo "::set-output name=count::$(git diff --name-only | wc -l)"
+
     - name: commit files
+      if: steps.changes.outputs.count > 0
       run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"


### PR DESCRIPTION
#5 や #7 でActionsが失敗していた原因を取り除きます。トポロジが変わらなかったときの条件分岐が足りていませんでした。
このworkflowでactionsが「トポロジ変わらなかったとき」「変わったとき」どちらも想定通り動くことを確認しました。
* https://github.com/ool-mddo/pushed_configs/actions/runs/1723391590
* https://github.com/ool-mddo/pushed_configs/actions/runs/1723412406